### PR TITLE
Make animations compatible with recent matplotlib.

### DIFF
--- a/PyNeuronToolbox/morphology.py
+++ b/PyNeuronToolbox/morphology.py
@@ -1,6 +1,6 @@
 from __future__ import division
 import numpy as np
-import pylab as plt
+import matplotlib.pyplot as plt
 from matplotlib.pyplot import cm
 import string
 from neuron import h


### PR DESCRIPTION
JSAnimation was merged into matplotlib, so the example notebook file wouldn't work. With these modifications it works nicely for me on a recent matplotlib (upgraded yesterday via anaconda).